### PR TITLE
Fix Linter Warnings from PR #6

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { Link } from "gatsby";
-import github from "../img/github-icon.svg";
 import logo from "../img/logo.svg";
 
 const Navbar = class extends React.Component {

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Link, graphql } from "gatsby";
+import { graphql } from "gatsby";
 
 import Layout from "../components/Layout";
 import Features from "../components/Features";


### PR DESCRIPTION
We accidentally introduced linter warnings in PR #6. Remove those so as not to confuse people.